### PR TITLE
Tweak indentation at bottom of list

### DIFF
--- a/data.json
+++ b/data.json
@@ -141,12 +141,12 @@
 					"overallscore": 3,
 					"review": "Rainbows End is Vinge's near future prediction book, it predicts a 'middle road' of the automation future between dystopia and utopia, feeling more realistic for the trying. At first a wonderous look at what the future might bring us (grounded in reality, focusing on ideas like augmented reality, computational currencies, and influencers; published nearly 15 years ago!) that becomes a terrifying look at what automation will mean for issues like terrorism (including a hard look at what computer privacy focused movements will have to contend with in the future). While the plot leaves somethings to be desired, the book is startingly evocative of a the near computational future."
 				},{
-                    "reviewer": "Crispin",
-                    "csprop": 0,
-                    "cscent": 0,
-                    "overallscore": 3,
-                    "review": "Not read this but from the other review, sounds more cyberpumk than hard-comp. This is a dummy review with some low hard-comp scores to balance things until I know more."
-                }
+                    			"reviewer": "Crispin",
+                    			"csprop": 0,
+                    			"cscent": 0,
+                    			"overallscore": 3,
+                    			"review": "Not read this but from the other review, sounds more cyberpumk than hard-comp. This is a dummy review with some low hard-comp scores to balance things until I know more."
+                		}
 			]
 		}, {
 			"title": "Cryptonomicon (Neal Stephenson)",
@@ -158,7 +158,7 @@
 					"overallscore": 5,
 					"review": "Stephenson shows off his habit of cramming as much research as possible into anything he writes. This book deals with a lot of cryptography, gold based digital currencies, data havens, and conception of the first computers around World War 2. The book also includes a novel cipher known as Pontifex with a working (depending on the edition) Perl script for using it. It's very long but justifies it's length by including two parallel stories. "
 				}
-            ]
+            		]
 		}, {
 			"title": "Permutation City (Greg Egan)",
 			"length": "Long",
@@ -170,6 +170,6 @@
 					"review": "Written by a software developer, Permutation City leans hard into the philosophy and realities of what artificial life in a computer simulation might be like. A little trippy, sometimes difficult to follow, but extremely thought-provoking nonetheless."
 				}
 			]
-        }
+        	}
     ]
 }


### PR DESCRIPTION
Manually tweaked some indentation. 

btw, I see the issue with pretty-print formatting using https://jsonformatter.org/json-pretty-print was I copied the text after hitting the 'Plain JSON' link, thinking it was like github's raw view. It is not, presents an html view that parses the links.